### PR TITLE
Liquidity pool trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,6 +2410,12 @@ dependencies = [
 [[package]]
 name = "module-traits"
 version = "0.0.1"
+dependencies = [
+ "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git)",
+ "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git)",
+]
 
 [[package]]
 name = "multistream-select"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,7 +2411,6 @@ dependencies = [
 name = "module-traits"
 version = "0.0.1"
 dependencies = [
- "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git)",
  "sr-std 2.0.0 (git+https://github.com/paritytech/substrate.git)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2408,6 +2408,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "module-traits"
+version = "0.0.1"
+
+[[package]]
 name = "multistream-select"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/modules/traits/Cargo.toml
+++ b/modules/traits/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
 sr-primitives = { git = "https://github.com/paritytech/substrate.git", default-features = false }
 rstd = { package = "sr-std", git = "https://github.com/paritytech/substrate.git", default-features = false }
-num-traits = { version = "0.2.8", default-features = false }
 
 [features]
 default = ["std"]
@@ -16,5 +15,4 @@ std = [
 	"codec/std",
 	"sr-primitives/std",
 	"rstd/std",
-	"num-traits/std",
 ]

--- a/modules/traits/Cargo.toml
+++ b/modules/traits/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "module-traits"
+version = "0.0.1"
+authors = ["Laminar Developers <hello@laminar.one>"]
+edition = "2018"
+
+[dependencies]

--- a/modules/traits/Cargo.toml
+++ b/modules/traits/Cargo.toml
@@ -5,3 +5,16 @@ authors = ["Laminar Developers <hello@laminar.one>"]
 edition = "2018"
 
 [dependencies]
+codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+sr-primitives = { git = "https://github.com/paritytech/substrate.git", default-features = false }
+rstd = { package = "sr-std", git = "https://github.com/paritytech/substrate.git", default-features = false }
+num-traits = { version = "0.2.8", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"sr-primitives/std",
+	"rstd/std",
+	"num-traits/std",
+]

--- a/modules/traits/src/lib.rs
+++ b/modules/traits/src/lib.rs
@@ -1,5 +1,30 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-pub trait LiquidityPool {
-	type LiquidityPoolId;
+use codec::FullCodec;
+use num_traits::Signed;
+use rstd::fmt::Debug;
+use sr_primitives::{traits::MaybeSerializeDeserialize, Permill};
+
+pub trait LiquidityPoolBaseTypes {
+	type LiquidityPoolId: FullCodec + Eq + PartialEq + Copy + MaybeSerializeDeserialize + Debug;
+	type CurrencyId: FullCodec + Eq + PartialEq + Copy + MaybeSerializeDeserialize + Debug;
 }
+
+pub trait LiquidityPoolsConfig: LiquidityPoolBaseTypes {
+	fn get_bid_spread(pool_id: Self::LiquidityPoolId, currency_id: Self::CurrencyId) -> Permill;
+	fn get_ask_spread(pool_id: Self::LiquidityPoolId, currency_id: Self::CurrencyId) -> Permill;
+	fn get_additional_collateral_ratio(pool_id: Self::LiquidityPoolId, currency_id: Self::CurrencyId) -> Permill;
+}
+
+pub trait LiquidityPoolsPosition: LiquidityPoolBaseTypes {
+	/// Signed leverage type: positive means long and negative means short.
+	type Leverage: Signed + FullCodec + Eq + PartialEq + PartialOrd + Ord + Copy + MaybeSerializeDeserialize + Debug;
+
+	fn is_allowed_position(
+		pool_id: Self::LiquidityPoolId,
+		currency_id: Self::CurrencyId,
+		leverage: Self::Leverage,
+	) -> bool;
+}
+
+pub trait LiquidityPools: LiquidityPoolsConfig + LiquidityPoolsPosition {}

--- a/modules/traits/src/lib.rs
+++ b/modules/traits/src/lib.rs
@@ -1,9 +1,16 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::FullCodec;
-use num_traits::Signed;
 use rstd::fmt::Debug;
 use sr_primitives::{traits::MaybeSerializeDeserialize, Permill};
+
+pub trait Leverage {
+	fn get_value() -> u8;
+	fn is_long(&self) -> bool;
+	fn is_short(&self) -> bool {
+		!self.is_long()
+	}
+}
 
 pub trait LiquidityPoolBaseTypes {
 	type LiquidityPoolId: FullCodec + Eq + PartialEq + Copy + MaybeSerializeDeserialize + Debug;
@@ -17,8 +24,7 @@ pub trait LiquidityPoolsConfig: LiquidityPoolBaseTypes {
 }
 
 pub trait LiquidityPoolsPosition: LiquidityPoolBaseTypes {
-	/// Signed leverage type: positive means long and negative means short.
-	type Leverage: Signed + FullCodec + Eq + PartialEq + PartialOrd + Ord + Copy + MaybeSerializeDeserialize + Debug;
+	type Leverage: Leverage;
 
 	fn is_allowed_position(
 		pool_id: Self::LiquidityPoolId,

--- a/modules/traits/src/lib.rs
+++ b/modules/traits/src/lib.rs
@@ -5,7 +5,7 @@ use rstd::fmt::Debug;
 use sr_primitives::{traits::MaybeSerializeDeserialize, Permill};
 
 pub trait Leverage {
-	fn get_value() -> u8;
+	fn get_value(&self) -> u8;
 	fn is_long(&self) -> bool;
 	fn is_short(&self) -> bool {
 		!self.is_long()

--- a/modules/traits/src/lib.rs
+++ b/modules/traits/src/lib.rs
@@ -1,0 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub trait LiquidityPool {
+	type LiquidityPoolId;
+}


### PR DESCRIPTION
Add a liquidity pool trait abstract for decoupling, to make liquidity pool module #8 development not a blocker for other runtime modules like #12 .